### PR TITLE
added the GetByRoute method to the wrapper and interface

### DIFF
--- a/UmbracoWrappers/DefaultUmbracoWrapper.cs
+++ b/UmbracoWrappers/DefaultUmbracoWrapper.cs
@@ -17,6 +17,11 @@ namespace Gibe.UmbracoWrappers
 			return CurrentUmbracoContext().ContentCache.GetById(id);
 		}
 
+		public IPublishedContent TypedContent(string url)
+		{
+			return CurrentUmbracoContext().ContentCache.GetByRoute(url);
+		}
+
 		public IPublishedContent TypedMedia(int id)
 		{
 			return CurrentUmbracoContext().MediaCache.GetById(id);

--- a/UmbracoWrappers/DefaultUmbracoWrapper.cs
+++ b/UmbracoWrappers/DefaultUmbracoWrapper.cs
@@ -17,14 +17,14 @@ namespace Gibe.UmbracoWrappers
 			return CurrentUmbracoContext().ContentCache.GetById(id);
 		}
 
-		public IEnumerable<IPublishedContent> TypedContentAtRoot()
-		{
-			return new UmbracoHelper(CurrentUmbracoContext()).TypedContentAtRoot();
-		}
-
 		public IPublishedContent TypedContent(string url)
 		{
 			return CurrentUmbracoContext().ContentCache.GetByRoute(url);
+		}
+
+		public IEnumerable<IPublishedContent> TypedContentAtRoot()
+		{
+			return new UmbracoHelper(CurrentUmbracoContext()).TypedContentAtRoot();
 		}
 
 		public IPublishedContent TypedMedia(int id)

--- a/UmbracoWrappers/IUmbracoWrapper.cs
+++ b/UmbracoWrappers/IUmbracoWrapper.cs
@@ -14,7 +14,8 @@ namespace Gibe.UmbracoWrappers
 
 		IPublishedContent TypedContent(int id);
 		IPublishedContent TypedContent(string url);
-		IEnumerable<IPublishedContent> TypedContentAtRoot();		IPublishedContent TypedMedia(int id);
+		IEnumerable<IPublishedContent> TypedContentAtRoot();
+		IPublishedContent TypedMedia(int id);
 
 		#region extension method replacements
 

--- a/UmbracoWrappers/IUmbracoWrapper.cs
+++ b/UmbracoWrappers/IUmbracoWrapper.cs
@@ -13,6 +13,7 @@ namespace Gibe.UmbracoWrappers
 		UmbracoContext CurrentUmbracoContext();
 
 		IPublishedContent TypedContent(int id);
+		IPublishedContent TypedContent(string url);
 		IPublishedContent TypedMedia(int id);
 
 		#region extension method replacements


### PR DESCRIPTION
i've created this as:

IPublishedContent TypedContent(string url);

which uses the 'GetByRoute()' method internally.

the thinking being we didn't call the other one

IPublishedContent GetById(int id);
